### PR TITLE
Update 18-3 - Destructuring Objects.md

### DIFF
--- a/18-3 - Destructuring Objects.md
+++ b/18-3 - Destructuring Objects.md
@@ -37,7 +37,7 @@ const speed = mySpeed || 760;
 console.log(speed); // 760!
 ```
 
-Why? Because ES6 destructuring default values only kick in if the value is not present. undefined, null, false and 0 are all still values!
+Why? Because ES6 destructuring default values only kick in if the value is undefined. null, false and 0 are all still values!
 
 ```js
 const { dogName = 'snickers' } = { dogName: undefined }


### PR DESCRIPTION
Fixes a typo. ES6 destructuring default values only kick in when the value is `undefined`.

This can be viewed as a follow-up to this commit https://github.com/wesbos/es6-articles/commit/b3c018f2806fb2f921aef7ee99eefa458d5d4484