### PR TITLE
README title links

### DIFF
--- a/10 - When NOT to use an Arrow Function.md
+++ b/10 - When NOT to use an Arrow Function.md
@@ -1,6 +1,6 @@
 Before you start going absolutely bananas on using arrow functions everywhere, we need to chat. **Arrow functions don't replace regular functions**. Just like Flexbox and floats, pixels and rems, and anything else new that comes along, the older thing still retains lots of utility because it works differently than the new thing. 
 
-We talked about the benefits of ES6 Arrow Functions in earlier videos and blog posts but let's go through a couple examples of when you probably _don't want an arrow function_. All of these are just going to boil down to not having the keyword `this`, but there are also different use cases that you'd run into. 
+We talked about the benefits of ES6 Arrow Functions in earlier videos and blog posts, but let's go through a couple examples of when you probably _don't want an arrow function_. All of these are just going to boil down to not having the keyword `this`, but there are also different use cases that you'd run into. 
 
 ### #1: Click Handlers
 
@@ -36,7 +36,7 @@ button.addEventListener('click', () => {
 });
 ```
 
-Remember: as we discussed with arrow functions, the keyword `this` is not bound to that element. If we use a regular function, the keyword `this` will be bound to the element we clicked!
+Remember: as we discussed with arrow functions, the keyword `this` is not bound to that element. If we use a regular function, the keyword `this` will be bound to the element we clicked:
 
 ```js
 const button = document.querySelector('#pushy');
@@ -46,11 +46,11 @@ button.addEventListener('click', function() {
 });
 ```
 
-In the console, `this` is now referring to our button, and our big yellow button is actually working. The sames rules apply with jQuery, Google Maps or any other DOM library you are using.
+In the console, `this` is now referring to our button, and our big yellow button is actually working. The same rules apply with jQuery, Google Maps, or any other DOM library you are using.
 
 ### #2: Object Methods
 
-Now, let's take a look at this next one, when we need a method to bind to an object. 
+Now, let's take a look at this next one, when we need a method to bind to an object: 
 
 ```js
 const person = {
@@ -80,11 +80,11 @@ const person = {
 }
 ```
 
-There we go. That will actually work, because that's a full on function, and not an arrow function.
+There we go. That will actually work, because that's a full on function and not an arrow function.
 
 ### 3: Prototype Methods
 
-As our third example, we'll talk about when we need to add a prototype method. 
+As our third example, we'll talk about when we need to add a prototype method: 
 
 ```js
 class Car {
@@ -118,9 +118,9 @@ Car.prototype.summarize = () => {
 };
 ```
 
-What that allows us to do is that, even after these cars have been created, we can add methods onto all of them. With our `Car.prototype.summarize` method set, let's type into the console: `subie.summarize`.
+What that allows us to do is, even after these cars have been created, we can add methods onto all of them. With our `Car.prototype.summarize` method set, let's type into the console: `subie.summarize`.
 
-If you're using Chrome's console, you'll see that it auto-completes the method, because it's available to you. Even though we added it after we created the `Car`, because I added it to the `prototype`, it's available in every object that has been created from there.
+If you're using Chrome's console, you'll see that it auto-completes the method because it's available to you. Even though we added it after we created the `Car`, because I added it to the `prototype`, it's available in every object that has been created from there.
 
 What this `prototype` does is it returns `this.make`, which is the make that we passed in, and `this.color` in a sentence.
 
@@ -138,7 +138,7 @@ Now, if we call `subie.summarize`, it says it's a white Subaru, and by calling `
 
 Again, we must use a regular function for that. 
 
-### 4: When we need an arguments Object
+### 4: When We Need an Arguments Object
 
 For our last example, this is a little bit different:
 
@@ -162,7 +162,7 @@ As an example, let's type into the console `orderChildren('jill', 'wes', 'jenna'
 
 This is because `arguments` is a keyword that we have in our `orderChildren`. That's going to give us an `Array` or array-ish value of everything that was passed in. 
 
-However, we do not get the `arguments` object if we use an arrow function. However, when we use a regular function, it is going to give us the actual content that we need.
+However, we do not get the `arguments` object if we use an arrow function. However, when we use a regular function, it is going to give us the actual content that we need:
 
 ```js
 const orderChildren = function() {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _example:_
 | 18 | [Destructuring Objects](https://wesbos.com/destructuring-objects/) | X | X |
 | 19 | Destructing Arrays | X | X |
 | 20 | [Swapping Variables with Destructuring](https://wesbos.com/destructuring-renaming/) | X | X |
-| 21 | [Destructuring Functions - Multiple returns and named defaults[(https://wesbos.com/destructuring-default-values/)] | X | |
+| 21 | [Destructuring Functions - Multiple returns and named defaults](https://wesbos.com/destructuring-default-values/) | X | |
 | 22 | The for of loop | X | |
 | 23 | The for of Loop in Action | X | |
 | 24 | Using for of with Objects | X | |

--- a/README.md
+++ b/README.md
@@ -22,25 +22,25 @@ _example:_
 |----------|:-------------|:------:|:------:|
 | 1 | [var Scoping Refresher](http://wesbos.com/javascript-scoping/) | X | X |
 | 2 | [let VS const](http://wesbos.com/let-vs-const/) | X | X |
-| 3 | let and const in the Real World | X | X |
-| 4 | Temporal Dead Zone | X | X |
-| 5 | Is var Dead? What should I use? | X | X |
-| 6 | Arrow Functions Introduction | X | X |
-| 7 | More Arrow Function Examples | X | X |
-| 8 | Arrow Functions and `this` | X | X |
-| 9 | Default Function Arguments | X | X |
-| 10 | When NOT to use an Arrow Function | X | X |
+| 3 | [let and const in the Real World](https://wesbos.com/let-vs-const/) | X | X |
+| 4 | [Temporal Dead Zone](https://wesbos.com/temporal-dead-zone/) | X | X |
+| 5 | [Is var Dead? What should I use?](https://wesbos.com/is-var-dead/) | X | X |
+| 6 | [Arrow Functions Introduction](https://wesbos.com/arrow-functions/) | X | X |
+| 7 | [More Arrow Function Examples](https://wesbos.com/arrow-function-examples/) | X | X |
+| 8 | [Arrow Functions and `this`](https://wesbos.com/arrow-functions-this-javascript/) | X | X |
+| 9 | [Default Function Arguments](https://wesbos.com/javascript-default-function-arguments/) | X | X |
+| 10 | [When NOT to use an Arrow Function](https://wesbos.com/arrow-function-no-no/) | X | X |
 | 11 | Arrow Functions Exercises | X | |
-| 12 | Template Strings Introduction | X | X |
+| 12 | [Template Strings Introduction](https://wesbos.com/javascript-template-strings/) | X | X |
 | 13 | Creating HTML fragments with Template Literals | X | |
-| 14 | Tagged Template Literals | X | |
+| 14 | [Tagged Template Literals](https://wesbos.com/tagged-template-literals/) | X | |
 | 15 | Tagged Templates Exercise | X | |
-| 16 | Santizing User Data with Tagged Templates | X | |
-| 17 | New String Methods | X | |
-| 18 | Destructuring Objects | X | X |
+| 16 | [Santizing User Data with Tagged Templates](https://wesbos.com/sanitize-html-es6-template-strings/) | X | |
+| 17 | [New String Methods](https://wesbos.com/new-es6-string-methods/) | X | |
+| 18 | [Destructuring Objects](https://wesbos.com/destructuring-objects/) | X | X |
 | 19 | Destructing Arrays | X | X |
-| 20 | Swapping Variables with Destructuring | X | X |
-| 21 | Destructuring Functions - Multiple returns and named defaults | X | |
+| 20 | [Swapping Variables with Destructuring](https://wesbos.com/destructuring-renaming/) | X | X |
+| 21 | [Destructuring Functions - Multiple returns and named defaults[(https://wesbos.com/destructuring-default-values/)] | X | |
 | 22 | The for of loop | X | |
 | 23 | The for of Loop in Action | X | |
 | 24 | Using for of with Objects | X | |


### PR DESCRIPTION
consistency with colons before code examples, capitalization in headers, couple of excessive commas (I am guilty of this always as well), and of course the Oxford comma. 